### PR TITLE
Try MIT keyserver before trying gnupg

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -30,7 +30,7 @@ curl --silent --retry 5 $BASE_URL/$SIGNATURE --output $SIGNATURE_PATH
 curl --silent --retry 5 $BASE_URL/$CHECKSUMS --output $CHECKSUMS_PATH
 
 echo "Verifying download" | indent
-gpg --quiet --keyserver keys.gnupg.net --recv 7BFB4EDA
+gpg --quiet --keyserver pgp.mit.edu --recv 7BFB4EDA || gpg --quiet --keyserver keys.gnupg.net --recv 7BFB4EDA
 gpg --quiet --verify $SIGNATURE_PATH $CHECKSUMS_PATH
 grep $(shasum -a 256 $TARBALL_PATH) $CHECKSUMS_PATH
 


### PR DESCRIPTION
TL;DR the MIT keyserver times out less than the gnupg server, so add
that as the primary keyserver and fall back to gnupg to lessen the
likelihood that a heroku deploy fails because of being unable to locate
the gnupg key.

In my Extremely Scientific tests, the gnupg server timed out (thus
causing the deploy to fail) 8 out of 13 attempts (62%). This server's
unreliability is a known issue [1].

I've added the MIT keyserver as the first place to check for the key; it
timed out 4 out of 13 attempts (31%).

I've left the gnupg server as a fallback; in the 4 times that the MIT
server timed out, the gnupg server did not time out, so ultimately 100%
of the attempts after this patch continued deploying rather than
stopping because of failing to get the key.

[1] - The RVM installation documentation at https://rvm.io/rvm/install
mentions that the gnupg server times out and recommends trying the MIT
server if it does.

Thanks!