### PR TITLE
Retry on failure: gpg --recv

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -30,7 +30,13 @@ curl --silent --retry 5 $BASE_URL/$SIGNATURE --output $SIGNATURE_PATH
 curl --silent --retry 5 $BASE_URL/$CHECKSUMS --output $CHECKSUMS_PATH
 
 echo "Verifying download" | indent
-gpg --quiet --keyserver pgp.mit.edu --recv 7BFB4EDA || gpg --quiet --keyserver keys.gnupg.net --recv 7BFB4EDA
+
+for i in 1 2 3 4; do
+  gpg --quiet --keyserver keys.gnupg.net --recv 7BFB4EDA
+  if [ $? = 0 ]; then
+    break;
+  fi
+done
 gpg --quiet --verify $SIGNATURE_PATH $CHECKSUMS_PATH
 grep $(shasum -a 256 $TARBALL_PATH) $CHECKSUMS_PATH
 


### PR DESCRIPTION
Switch back to keys.gnupg.net which is a CNAME for hkps.pool.sks-keyservers.net and retry four times on failure.

This fixes #6 and is a follow-up to #7.