### PR TITLE
Decrease the GnuPG keyserver timeout

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -32,7 +32,10 @@ curl --silent --retry 5 $BASE_URL/$CHECKSUMS --output $CHECKSUMS_PATH
 echo "Verifying download" | indent
 
 for i in 1 2 3 4; do
-  gpg --quiet --keyserver keys.gnupg.net --recv-keys CBA23971357C2E6590D9EFD3EC8FEF3A7BFB4EDA
+  gpg --quiet \
+      --keyserver keys.gnupg.net \
+      --keyserver-options timeout=5 \
+      --recv-keys CBA23971357C2E6590D9EFD3EC8FEF3A7BFB4EDA
   if [ $? = 0 ]; then
     break;
   fi


### PR DESCRIPTION
The man page says default is 30 seconds, but in my experience/testing in
Ubuntu, timeout takes two minutes.

Also, when it works, it works right away, in less than a second.